### PR TITLE
add official support of drupal 10.0 (with CKEditor 4) && drop support of drupal below 9.5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,25 +12,22 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.3', '9.4', '9.5']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2']
         module: ['nbsp']
-        experimental: [false]
 
     steps:
-      - uses: actions/checkout@v3
-      - run: docker-compose -f docker-compose.yml pull --include-deps drupal
-      - name: Build the docker-compose stack
-        run: docker-compose -f docker-compose.yml build --pull --build-arg BASE_IMAGE_TAG=${{ matrix.drupal_version }} drupal
-        continue-on-error: ${{ matrix.experimental }}
+      - uses: actions/checkout@v4
+      - run: docker compose -f docker-compose.yml pull --include-deps drupal
+      - name: Build the docker compose stack
+        run: docker compose -f docker-compose.yml build --pull --build-arg BASE_IMAGE_TAG=${{ matrix.drupal_version }} drupal
       - name: Up a persistent Docker Container
-        run: docker-compose -f docker-compose.yml up -d drupal
+        run: docker compose -f docker-compose.yml up -d drupal
       - name: wait on Docker to be ready, especially Apache that takes many seconds to be up
-        run: docker-compose exec -T drupal wait-for-it drupal:80 -t 60
+        run: docker compose exec -T drupal wait-for-it drupal:80 -t 60
       - name: wait on Docker to be ready, especially MariaDB that takes many seconds to be up
-        run: docker-compose exec -T drupal wait-for-it db:3306 -t 60
+        run: docker compose exec -T drupal wait-for-it db:3306 -t 60
       - name: Run unit tests
-        run: docker-compose -f docker-compose.yml exec -T -u www-data drupal phpunit --no-coverage --group=${{ matrix.module }} --exclude-group=${{ matrix.module }}_functional --configuration=/var/www/html/phpunit.xml
-        continue-on-error: ${{ matrix.experimental }}
+        run: docker compose -f docker-compose.yml exec -T -u www-data drupal phpunit --no-coverage --group=${{ matrix.module }} --exclude-group=${{ matrix.module }}_functional --configuration=/var/www/html/phpunit.xml
 
   tests-functional:
     name: Functional Tests
@@ -39,30 +36,27 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.3', '9.4', '9.5']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2']
         module: ['nbsp']
         experimental: [false]
 
     steps:
-      - uses: actions/checkout@v3
-      - run: docker-compose -f docker-compose.yml pull --include-deps drupal
-      - name: Build the docker-compose stack
-        run: docker-compose -f docker-compose.yml build --pull --build-arg BASE_IMAGE_TAG=${{ matrix.drupal_version }} drupal
-        continue-on-error: ${{ matrix.experimental }}
+      - uses: actions/checkout@v4
+      - run: docker compose -f docker-compose.yml pull --include-deps drupal
+      - name: Build the docker compose stack
+        run: docker compose -f docker-compose.yml build --pull --build-arg BASE_IMAGE_TAG=${{ matrix.drupal_version }} drupal
       - name: Up a persistent Docker Container
-        run: docker-compose -f docker-compose.yml up -d drupal chrome
+        run: docker compose -f docker-compose.yml up -d drupal chrome
       - name: wait on Docker to be ready, especially Apache that takes many seconds to be up
-        run: docker-compose exec -T drupal wait-for-it drupal:80 -t 60
+        run: docker compose exec -T drupal wait-for-it drupal:80 -t 60
       - name: wait on Docker to be ready, especially MariaDB that takes many seconds to be up
-        run: docker-compose exec -T drupal wait-for-it db:3306 -t 60
+        run: docker compose exec -T drupal wait-for-it db:3306 -t 60
       - name: wait on Docker to be ready, especially Chrome that takes many seconds to be up
-        run: docker-compose exec -T drupal wait-for-it chrome:9515 -t 60
+        run: docker compose exec -T drupal wait-for-it chrome:9515 -t 60
       - name: Bootstrap Drupal
-        run: docker-compose -f docker-compose.yml exec -T -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
-        continue-on-error: ${{ matrix.experimental }}
+        run: docker compose -f docker-compose.yml exec -T -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
       - name: Run tests
-        run: docker-compose -f docker-compose.yml exec -T -u www-data drupal phpunit --no-coverage --group=${{ matrix.module }}_functional --configuration=/var/www/html/phpunit.xml --fail-on-risky
-        continue-on-error: ${{ matrix.experimental }}
+        run: docker compose -f docker-compose.yml exec -T -u www-data drupal phpunit --no-coverage --group=${{ matrix.module }}_functional --configuration=/var/www/html/phpunit.xml --fail-on-risky
 
   upgrade-status:
     name: Upgrade Status
@@ -74,21 +68,21 @@ jobs:
         module: ['nbsp']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - run: docker-compose -f docker-compose.yml pull --include-deps drupal
-      - name: Build the docker-compose stack
-        run: docker-compose -f docker-compose.yml build --pull --build-arg BASE_IMAGE_TAG=${{ matrix.drupal_version }} drupal
+      - run: docker compose -f docker-compose.yml pull --include-deps drupal
+      - name: Build the docker compose stack
+        run: docker compose -f docker-compose.yml build --pull --build-arg BASE_IMAGE_TAG=${{ matrix.drupal_version }} drupal
       - name: Up a persistent Docker Container
-        run: docker-compose -f docker-compose.yml up -d drupal
+        run: docker compose -f docker-compose.yml up -d drupal
       - name: Add upgrade status dependency
-        run: docker-compose exec -T drupal wait-for-it db:3306 -- composer require --dev drupal/upgrade_status --no-interaction
+        run: docker compose exec -T drupal wait-for-it db:3306 -- composer require --dev drupal/upgrade_status --no-interaction
       - name: Bootstrap Drupal
-        run: docker-compose -f docker-compose.yml exec -T -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
+        run: docker compose -f docker-compose.yml exec -T -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
       - name: Enable upgrade status
-        run: docker-compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush en upgrade_status -y
+        run: docker compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush en upgrade_status -y
       - name: Enable the module
-        run: docker-compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush en ${{ matrix.module }} -y
+        run: docker compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush en ${{ matrix.module }} -y
       - name: Run upgrade status
-        run: docker-compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush upgrade_status:analyze ${{ matrix.module }}
+        run: docker compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush upgrade_status:analyze ${{ matrix.module }}

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -6,7 +6,7 @@ jobs:
     name: eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install modules
         run: yarn
       - name: Run ESLint
@@ -16,7 +16,7 @@ jobs:
     name: prettier
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install modules
         run: yarn
       - name: Run Prettier
@@ -29,10 +29,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-          tools: cs2pr, composer:v1
-      - uses: actions/checkout@v3
+          tools: cs2pr, composer:v2
+      - uses: actions/checkout@v4
       - run: composer install --prefer-dist
       - run: ./vendor/bin/phpcs ./ --report=checkstyle | cs2pr
 
@@ -43,10 +43,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-          tools: cs2pr, composer:v1, phpmd
-      - uses: actions/checkout@v3
+          tools: cs2pr, composer:v2, phpmd
+      - uses: actions/checkout@v4
       - run: composer install --prefer-dist
       - run: phpmd ./ text ./phpmd.xml --suffixes php,module,inc,install,test,profile,theme,css,info,txt --exclude *Test.php,*vendor/*
 
@@ -57,10 +57,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-          tools: cs2pr, composer:v1, phpcpd
-      - uses: actions/checkout@v3
+          tools: cs2pr, composer:v2, phpcpd
+      - uses: actions/checkout@v4
       - run: composer install --prefer-dist
       - run: phpcpd ./src --suffix .php --suffix .module --suffix .inc --suffix .install --suffix .test --suffix .profile --suffix .theme --suffix .css --suffix .info --suffix .txt --exclude *.md --exclude *.info.yml --exclude tests --exclude vendor/
 
@@ -68,9 +68,9 @@ jobs:
     name: PhpDeprecationDetector (phpdd)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: docker-compose -f docker-compose.yml pull --include-deps drupal
-      - name: Build the docker-compose stack
-        run: docker-compose -f docker-compose.yml build drupal
+      - uses: actions/checkout@v4
+      - run: docker compose -f docker-compose.yml pull --include-deps drupal
+      - name: Build the docker compose stack
+        run: docker compose -f docker-compose.yml build drupal
       - name: Run phpdd
-        run: docker-compose run drupal phpdd ./web/modules/contrib/nbsp/ --file-extensions php,module,inc,install,test,profile,theme,info --exclude vendor
+        run: docker compose run drupal phpdd ./web/modules/contrib/editor_advanced_image/ --file-extensions php,module,inc,install,test,profile,theme,info --exclude vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official support of drupal 10.0 (with CKEditor 4)
+- add coverage of Drupal 10.1.x
+- add coverage of Drupal 10.2.x
+
+### Changed
+- fix tests on Drupal 10.2+ using HTML5 filter
+
+### Removed
+- drop support of drupal below 9.5.x
 
 ## [2.3.0] - 2023-06-02
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,22 +20,22 @@ First of all, you will need to have the following tools installed
 globally on your environment:
 
   * drush
-  * Latest dev release of Drupal 8.x|9.x.
+  * Latest dev release of Drupal
   * docker
-  * docker-compose
+  * docker compose
 
 ### Project bootstrap
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker-compose build --pull --build-arg BASE_IMAGE_TAG=9.3 drupal
+    docker compose build --pull --build-arg BASE_IMAGE_TAG=9.5 drupal
     (get a coffee, this will take some time...)
-    docker-compose up -d drupal chrome
-    docker-compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
+    docker compose up -d drupal chrome
+    docker compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
 
-    # You may be interesed by reseting the admin passowrd of your Docker and install the module using those cmd.
-    docker-compose exec drupal drush user:password admin admin
-    docker-compose exec drupal drush en nbsp
+    # You may be interesed by resetting the admin password of your Docker and install the module using those cmd.
+    docker compose exec drupal drush user:password admin admin
+    docker compose exec drupal drush en nbsp
 
 ## 🏆 Tests
 
@@ -43,7 +43,7 @@ We use the [Docker for Drupal Contrib images](https://hub.docker.com/r/wengerk/d
 
 Run testing by stopping at first failure using the following command:
 
-    docker-compose exec -u www-data drupal phpunit --group=nbsp --no-coverage --stop-on-failure --configuration=/var/www/html/phpunit.xml
+    docker compose exec -u www-data drupal phpunit --group=nbsp --no-coverage --stop-on-failure --configuration=/var/www/html/phpunit.xml
 
 ## 🚔 Check Javascript best practices
 
@@ -73,7 +73,7 @@ The following Analyzer will be downloaded & installed as PHAR:
 
     ./scripts/hooks/post-commit
     # or run command on the container itself
-    docker-compose exec drupal bash
+    docker compose exec drupal bash
 
 #### Running Code Sniffer Drupal & DrupalPractice
 
@@ -85,13 +85,13 @@ violations.
 PHP_CodeSniffer is an essential development tool that ensures your code remains clean and consistent.
 
   ```
-  $ docker-compose exec drupal ./vendor/bin/phpcs ./web/modules/contrib/nbsp/
+  $ docker compose exec drupal ./vendor/bin/phpcs ./web/modules/contrib/nbsp/
   ```
 
 Automatically fix coding standards
 
   ```
-  $ docker-compose exec drupal ./vendor/bin/phpcbf ./web/modules/contrib/nbsp/
+  $ docker compose exec drupal ./vendor/bin/phpcbf ./web/modules/contrib/nbsp/
   ```
 
 #### Running PHP Mess Detector
@@ -101,7 +101,7 @@ https://github.com/phpmd/phpmd
 Detect overcomplicated expressions & Unused parameters, methods, properties.
 
   ```
-  $ docker-compose exec drupal phpmd ./web/modules/contrib/nbsp/ text ./phpmd.xml \
+  $ docker compose exec drupal phpmd ./web/modules/contrib/nbsp/ text ./phpmd.xml \
   --suffixes php,module,inc,install,test,profile,theme,css,info,txt --exclude *Test.php,*vendor/*,*node_modules/*
   ```
 
@@ -112,7 +112,7 @@ https://github.com/sebastianbergmann/phpcpd
 `phpcpd` is a Copy/Paste Detector (CPD) for PHP code.
 
   ```
-  $ docker-compose exec drupal phpcpd ./web/modules/contrib/nbsp/src --suffix .php --suffix .module --suffix .inc --suffix .install --suffix .test --suffix .profile --suffix .theme --suffix .css --suffix .info --suffix .txt --exclude *.md --exclude *.info.yml --exclude tests --exclude vendor/ --exclude node_modules/
+  $ docker compose exec drupal phpcpd ./web/modules/contrib/nbsp/src --suffix .php --suffix .module --suffix .inc --suffix .install --suffix .test --suffix .profile --suffix .theme --suffix .css --suffix .info --suffix .txt --exclude *.md --exclude *.info.yml --exclude tests --exclude vendor/ --exclude node_modules/
   ```
 
 #### Running PhpDeprecationDetector
@@ -122,7 +122,7 @@ https://github.com/wapmorgan/PhpDeprecationDetector
 A scanner that checks compatibility of your code with PHP interpreter versions.
 
   ```
-  $ docker-compose exec drupal phpdd ./web/modules/contrib/nbsp/ \
+  $ docker compose exec drupal phpdd ./web/modules/contrib/nbsp/ \
     --file-extensions php,module,inc,install,test,profile,theme,info --exclude vendor --exclude node_modules
   ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-ARG BASE_IMAGE_TAG=9.3
+ARG BASE_IMAGE_TAG=9.5
 FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 
 # Disable deprecation notice as CKEditor4 module will throw an exception until we remove support of Drupal 9.
 ENV SYMFONY_DEPRECATIONS_HELPER=disabled
+
+# Install drupal/ckeditor (CKEditor 4) as we keep supporting CK4 & CK5.
+ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN COMPOSER_MEMORY_LIMIT=-1 composer require "drupal/ckeditor"
 
 # Register the Drupal and DrupalPractice Standard with PHPCS.
 RUN ./vendor/bin/phpcs --config-set installed_paths \

--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 Minimal module to insert a non-breaking space (`&nbsp;`)
 into the content by pressing Ctrl+Space or using the provided button.
 
-|       Travis-CI        |        Downloads        |         Releases         |
-|:----------------------:|:-----------------------:|:------------------------:|
-| [![Build Status](https://github.com/antistatique/drupal-ckeditor-nbsp/actions/workflows/ci.yml/badge.svg)](https://github.com/antistatique/drupal-ckeditor-nbsp/actions/workflows/ci.yml) | [![Code styles](https://github.com/antistatique/drupal-ckeditor-nbsp/actions/workflows/styles.yml/badge.svg)](https://github.com/antistatique/drupal-ckeditor-nbsp/actions/workflows/styles.yml) | [![Latest Stable Version](https://img.shields.io/badge/release-v2.0-blue.svg?style=flat-square)](https://www.drupal.org/project/nbsp/releases) |
-
 ## Uses
 
 During content creation the author may add a non-breaking space (`&nbsp;`)
@@ -53,7 +49,11 @@ NBSP is now available for both Drupal 8, Drupal 9 & Drupal 10!
 
 ## Dependencies
 
-The Drupal 8, Drupal 9 & Drupal 10 of NBSP requires
+The Drupal 10 version of NBSP requires
+[Editor](https://www.drupal.org/project/editor) and
+[CKEditor 5](https://ckeditor.com/ckeditor-5/).
+
+The Drupal 8 & Drupal 9 versions of NBSP requires
 [Editor](https://www.drupal.org/project/editor) and
 [CKEditor](https://www.drupal.org/project/ckeditor).
 

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
   "license": "GPL-2.0-or-later",
   "require-dev": {
     "drupal/coder": "^8.3.1"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: always
 
   db:
-    image: mariadb:10.3.7
+    image: mariadb:10.3.8
     environment:
       MYSQL_USER: drupal
       MYSQL_PASSWORD: drupal

--- a/nbsp.info.yml
+++ b/nbsp.info.yml
@@ -1,7 +1,7 @@
 name: 'CKEditor Non-breaking space Plugin'
 type: module
 description: 'Minimal module to insert a non-breaking space into the content by pressing Ctrl+Space or using the provided button.'
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.5 || ^10
 package: CKEditor
 
 dependencies:

--- a/tests/src/Kernel/NbspCleanerFilterTest.php
+++ b/tests/src/Kernel/NbspCleanerFilterTest.php
@@ -50,6 +50,12 @@ class NbspCleanerFilterTest extends KernelTestBase {
     /** @var \Drupal\filter\FilterProcessResult $result */
     $result = $filter->process($input, 'und');
     $this->assertInstanceOf(FilterProcessResult::class, $result);
+
+    // Since Drupal 10.2.0 use filter system HTML5.
+    if (version_compare(\Drupal::VERSION, '10.2.0', '>')) {
+      $expected = str_replace(' ', '&nbsp;', $expected);
+    }
+
     $this->assertEquals($expected, $result->getProcessedText());
   }
 
@@ -63,6 +69,10 @@ class NbspCleanerFilterTest extends KernelTestBase {
       [
         '<p>Maecenas<nbsp>&nbsp;</nbsp>cursus posuere</p>',
         '<p>Maecenas cursus posuere</p>',
+      ],
+      [
+        '<p>Maecenas <a href="https://www.google.ch">lorem<nbsp>&nbsp;</nbsp>ipsum</a><nbsp>&nbsp;</nbsp>cursus<nbsp>&nbsp;</nbsp>posuere</p>',
+        '<p>Maecenas <a href="https://www.google.ch">lorem ipsum</a> cursus posuere</p>',
       ],
       [
         '<p>Maecenas<nbsp>&nbsp;</nbsp>cursus<nbsp>&nbsp;</nbsp>posuere</p>',


### PR DESCRIPTION
### 💬 Description
- drop support of drupal below 9.5.x
- add official support of drupal 10.0 (with CKEditor 4)

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
