### PR TITLE
add official stable support for drupal 10.4 & 11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0', '10.1', '10.2', '10.3']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['nbsp']
         experimental: [false]
         include:
-          - drupal_version: '11.0'
+          - drupal_version: '10.5'
+            module: 'nbsp'
+            experimental: true
+          - drupal_version: '11.2'
             module: 'nbsp'
             experimental: true
 
@@ -42,11 +45,14 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0', '10.1', '10.2']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['nbsp']
         experimental: [false]
         include:
-          - drupal_version: '11.0'
+          - drupal_version: '10.5'
+            module: 'nbsp'
+            experimental: true
+          - drupal_version: '11.2'
             module: 'nbsp'
             experimental: true
 
@@ -77,7 +83,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0']
+        drupal_version: ['10.4']
         module: ['nbsp']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official support of drupal 10.4
+- add official support of drupal 11.1
+
 ### Fixed
 - fix issue #3432756 by wengerk, drunir, ksenzee: Splitting the links in two
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fix issue #3432756 by wengerk, drunir, ksenzee: Splitting the links in two
 
+### Changed
+- update Docker MariaDB 10.3 -> 10.6
+
 ### Removed
 - remove legacy version annotation on docker-compose.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fix issue #3432756 by wengerk, drunir, ksenzee: Splitting the links in two
 
+### Removed
+- remove legacy version annotation on docker-compose.yml
+
 ## [3.0.2] - 2024-05-30
 ### Added
 - add coverage of Drupal 10.1.x

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   drupal:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     restart: always
 
   db:
-    image: mariadb:10.3.8
+    image: mariadb:10.6
     environment:
       MYSQL_USER: drupal
       MYSQL_PASSWORD: drupal


### PR DESCRIPTION
### 💬 Description
add official stable support for drupal 10.4 & 11.1

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
