### PR TITLE
update drupal version support (drop < 10.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,11 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.5', '11.0', '11.1', '11.2']
         module: ['nbsp']
         experimental: [false]
         include:
-          - drupal_version: '10.5'
-            module: 'nbsp'
-            experimental: true
-          - drupal_version: '11.2'
+          - drupal_version: '11.3'
             module: 'nbsp'
             experimental: true
 
@@ -45,14 +42,11 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.5', '11.0', '11.1', '11.2']
         module: ['nbsp']
         experimental: [false]
         include:
-          - drupal_version: '10.5'
-            module: 'nbsp'
-            experimental: true
-          - drupal_version: '11.2'
+          - drupal_version: '11.3'
             module: 'nbsp'
             experimental: true
 
@@ -83,7 +77,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.4']
+        drupal_version: ['10.5']
         module: ['nbsp']
 
     steps:

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2
       - uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpmd
       - uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpcpd
       - uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,11 +31,14 @@ include:
 variables:
   # Opt in to testing current minor against max supported PHP version.
   OPT_IN_TEST_MAX_PHP: '1'
-  # Opt in to testing previous & next minor (Drupal 10.0.x and 10.2.x).
+  # Opt in to testing previous minor (Drupal 11.1.x).
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
+  # Opt in to testing minor (Drupal 11.3-dev).
   OPT_IN_TEST_NEXT_MINOR: '1'
-  # The 3.x branch of the NBSP module requires Drupal 10.x minimum.
-  CORE_PREVIOUS_PHP_MIN: '8.1'
+  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 10.5.x).
+  OPT_IN_TEST_PREVIOUS_MAJOR: '1'
+  # The 3.0.x branch of the module requires Drupal 10.5 minimum.
+  CORE_PREVIOUS_PHP_MIN: '8.3'
   # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 11).
   OPT_IN_TEST_NEXT_MAJOR: '1'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - update cpsell allowed words
+- add official support of drupal 10.5
+- add official support of drupal 11.2
+
+### Removed
+- drop support of drupal 10.4.x
+- drop support of drupal 10.3.x
+- drop support of drupal 10.2.x
+- drop support of drupal 10.1.x
+- drop support of drupal 10.0.x
 
 ## [3.0.3] - 2025-03-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - drop support of drupal 10.1.x
 - drop support of drupal 10.0.x
 
+### Fixed
+- fix styelint css rgba -> rgb function
+
 ## [3.0.3] - 2025-03-20
 ### Added
 - add official support of drupal 10.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ globally on your environment:
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker compose build --pull --build-arg BASE_IMAGE_TAG=10.1 drupal
+    docker compose build --pull --build-arg BASE_IMAGE_TAG=11.2 drupal
     (get a coffee, this will take some time...)
     docker compose up -d drupal chrome
     docker compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG=10.1
+ARG BASE_IMAGE_TAG=11.2
 FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 
 # Disable deprecation notice as CKEditor4 module will throw an exception until we remove support of Drupal 9.

--- a/css/ckeditor.nbsp.css
+++ b/css/ckeditor.nbsp.css
@@ -1,15 +1,15 @@
 /* stylelint-disable selector-type-no-unknown -- Custom element nbsp has been created on purpose for CKEditor5. */
 nbsp {
   display: inline-block;
-  border: 2px solid rgba(0, 123, 198, 1);
-  background-color: rgba(0, 123, 198, 0.4);
+  border: 2px solid rgb(0, 123, 198, 1);
+  background-color: rgb(0, 123, 198, 0.4);
 }
 
 /**
  * The previous tag (span.nbsp) is still on the filter to keep compatibility with previous content created.
  */
 span.nbsp {
-  border: 1px solid rgba(0, 123, 198, 1);
-  background-color: rgba(0, 123, 198, 0.4);
+  border: 1px solid rgb(0, 123, 198, 1);
+  background-color: rgb(0, 123, 198, 0.4);
 }
 /* stylelint-enable selector-type-no-unknown */

--- a/nbsp.info.yml
+++ b/nbsp.info.yml
@@ -1,7 +1,7 @@
 name: 'CKEditor Non-breaking space Plugin'
 type: module
 description: 'Minimal module to insert a non-breaking space into the content by pressing Ctrl+Space or using the provided button.'
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.5 || ^11
 package: CKEditor
 
 dependencies:

--- a/tests/src/FunctionalJavascript/DrupalCKEditor5NbspTest.php
+++ b/tests/src/FunctionalJavascript/DrupalCKEditor5NbspTest.php
@@ -224,14 +224,7 @@ class DrupalCKEditor5NbspTest extends WebDriverTestBase {
     $this->pressEditorButton('Insert non-breaking space');
 
     $this->assertNotEmpty($assert_session->waitForElement('css', '.ck-editor__editable a em > nbsp'));
-
-    // Since Drupal 10.1.0.
-    if (version_compare(\Drupal::VERSION, '10.1.0', '>')) {
-      $this->assertEquals('<p>lorem ipsum <a href="https://www.google.ch" class="ck-link_selected">dolore<em><nbsp><br data-cke-filler="true"></nbsp></em>dolo</a> amet.</p>', $editor->getHtml());
-    }
-    else {
-      $this->assertEquals('<p>lorem ipsum <a href="https://www.google.ch">dolore<em><nbsp><br data-cke-filler="true"></nbsp></em>dolo</a> amet.</p>', $editor->getHtml());
-    }
+    $this->assertEquals('<p>lorem ipsum <a href="https://www.google.ch" class="ck-link_selected">dolore<em><nbsp><br data-cke-filler="true"></nbsp></em>dolo</a> amet.</p>', $editor->getHtml());
 
     // The link should be left intact and we should have 1 NBSP element inside.
     $xpath = new \DOMXPath($this->getEditorDataAsDom());

--- a/tests/src/Kernel/NbspCleanerFilterTest.php
+++ b/tests/src/Kernel/NbspCleanerFilterTest.php
@@ -51,11 +51,6 @@ class NbspCleanerFilterTest extends KernelTestBase {
     $result = $filter->process($input, 'und');
     $this->assertInstanceOf(FilterProcessResult::class, $result);
 
-    // Since Drupal 10.2.0 use filter system HTML5.
-    if (version_compare(\Drupal::VERSION, '10.2.0', '>')) {
-      $expected = str_replace(' ', '&nbsp;', $expected);
-    }
-
     $this->assertEquals($expected, $result->getProcessedText());
   }
 
@@ -68,23 +63,23 @@ class NbspCleanerFilterTest extends KernelTestBase {
       ['<p>Maecenas cursus posuere</p>', '<p>Maecenas cursus posuere</p>'],
       [
         '<p>Maecenas<nbsp>&nbsp;</nbsp>cursus posuere</p>',
-        '<p>Maecenas cursus posuere</p>',
+        '<p>Maecenas&nbsp;cursus posuere</p>',
       ],
       [
         '<p>Maecenas <a href="https://www.google.ch">lorem<nbsp>&nbsp;</nbsp>ipsum</a><nbsp>&nbsp;</nbsp>cursus<nbsp>&nbsp;</nbsp>posuere</p>',
-        '<p>Maecenas <a href="https://www.google.ch">lorem ipsum</a> cursus posuere</p>',
+        '<p>Maecenas <a href="https://www.google.ch">lorem&nbsp;ipsum</a>&nbsp;cursus&nbsp;posuere</p>',
       ],
       [
         '<p>Maecenas<nbsp>&nbsp;</nbsp>cursus<nbsp>&nbsp;</nbsp>posuere</p>',
-        '<p>Maecenas cursus posuere</p>',
+        '<p>Maecenas&nbsp;cursus&nbsp;posuere</p>',
       ],
       [
         '<p>Maecenas<div class="nbsp">&nbsp;</div>cursus posuere</p>',
-        '<p>Maecenas</p><div class="nbsp"> </div>cursus posuere',
+        '<p>Maecenas</p><div class="nbsp">&nbsp;</div>cursus posuere',
       ],
       [
         '<p>Maecenas<span>&nbsp;</span>cursus posuere</p>',
-        '<p>Maecenas<span> </span>cursus posuere</p>',
+        '<p>Maecenas<span>&nbsp;</span>cursus posuere</p>',
       ],
     ];
   }


### PR DESCRIPTION
### 💬 Description
update drupal version support (drop < 10.5)
[fix styelint css rgba -> rgb function](https://github.com/antistatique/drupal-ckeditor-nbsp/commit/f7acb9d18548423e88a2558617eaff910c3367d5)

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
